### PR TITLE
Add a mininified + gzipped bundle size badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Version](https://img.shields.io/badge/Version-2.0.0--beta-1a2a3a.svg)](https://github.com/rqrauhvmra/Tobii/releases)
 [![License](https://img.shields.io/badge/License-MIT-1a2a3a.svg)](https://github.com/rqrauhvmra/Tobii/blob/master/LICENSE.md)
 ![Dependecies](https://img.shields.io/badge/Dependencies-none-1a2a3a.svg)
+![npm bundle size](https://img.shields.io/bundlephobia/minzip/tobii?color=1a2a3a)
 [![Amazon wishlist](https://img.shields.io/badge/Amazon_wishlist-0366d6.svg)](https://www.amazon.de/hz/wishlist/ls/29WXITO63O0BX)
 
 An accessible, open-source lightbox with no dependencies.


### PR DESCRIPTION
This lets users quickly see how large the library is once integrated on a website.

## Preview

![Badges](https://user-images.githubusercontent.com/180032/103694307-1376a580-4f9b-11eb-8903-2b19810967bf.png)