### PR TITLE
Remove publishConfig from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,5 @@
   "bugs": {
     "url": "https://github.com/midzer/tobii/issues"
   },
-  "homepage": "https://github.com/midzer/tobii",
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com/@midzer"
-  }
+  "homepage": "https://github.com/midzer/tobii"
 }


### PR DESCRIPTION
This is actually breaking the GitHub workflow for publishing to npm and GitHub.