### PR TITLE
Fix exception when clicking the back button

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -521,7 +521,7 @@ export default function Tobii (userOptions) {
     unbindEvents()
 
     // Remove entry in browser history
-    if (window.history.state !== null) {
+    if (window.history.state) {
       if (window.history.state.tobii === 'close') {
         window.history.back()
       }


### PR DESCRIPTION
Hello, first of all thanks for this awesome lib!

This MR fixes a specific issue I've run into:

## Reproduction

- Multiple images with tobiified links (aka popup links)
- Open one image, navigate to the next one along
- Click the browser back button
- An Exception is thrown `Uncaught TypeError: Cannot read properties of undefined (reading 'tobii')`

## Cause

- Using the back button (aka popstate event) does not add the state object to the browser history
- `window.history.state` is undefined (even though the specs say it [should be null](https://developer.mozilla.org/en-US/docs/Web/API/History/state#value) :shrug: 
- The comparison checks for `window.history.state !== null` which is true when the `state` is undefined but causes the exception in the next line.

## Finally...

IMHO I think this is a good fix since we don't need the call to `window.history.back` at this point anyway. The check for a falsy value handles both cases (the back button case and the "I just opened the popup and now want to close it" case)

Let me know if you agree or if you want something changed. Cheers.