### PR TITLE
Accessibility improvements

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -376,6 +376,8 @@ export default function Tobii (userOptions) {
     lightbox = document.createElement('div')
     lightbox.setAttribute('role', 'dialog')
     lightbox.setAttribute('aria-hidden', 'true')
+    lightbox.setAttribute('aria-modal', 'true')
+    lightbox.setAttribute('aria-label', 'Lightbox')
     lightbox.classList.add('tobii')
 
     // Adc theme class

--- a/src/js/types/image.js
+++ b/src/js/types/image.js
@@ -13,6 +13,9 @@ class ImageType {
     const THUMBNAIL = el.querySelector('img')
     const LOADING_INDICATOR = document.createElement('div')
 
+    // Add role="group" to figure
+    FIGURE.setAttribute('role', 'group')
+
     // Hide figure until the image is loaded
     FIGURE.style.opacity = '0'
 
@@ -54,6 +57,9 @@ class ImageType {
         FIGURE.appendChild(FIGCAPTION)
 
         IMAGE.setAttribute('aria-labelledby', FIGCAPTION.id)
+
+        // Add aria-label to the figure containing the caption content
+        FIGURE.setAttribute('aria-label', FIGCAPTION.textContent)
 
         ++this.figcaptionId
       }


### PR DESCRIPTION
These improvements were suggested by the [Temesis](https://www.temesis.com/) accessibility audit company.

### `role="group"`

In web accessibility, adding `role="group"` to a `<figure>` element can enhance the experience for screen reader users by explicitly grouping related content together and providing additional semantic meaning where necessary.

This is particularly useful when:

**1. Providing Context in Complex Figures**

A `<figure>` element can contain a visual representation (e.g., an image, chart, or diagram) and its associated `<figcaption>`. Adding `role="group"` explicitly communicates to assistive technologies that these elements are part of a cohesive unit.

Example: If the `<figure>` has multiple related child elements, such as an image and a textual legend, the grouping helps screen readers navigate and understand the relationship between them.

**2. Reinforcing Semantic Relationships**

While `<figure> `has inherent semantic meaning, some assistive technologies may not fully recognize it, or the grouping intention might need to be clarified in more complex scenarios. Using `role="group"` ensures consistent behavior across all devices and software.

**3. Enhancing Navigation**

Screen reader users often navigate by landmarks or regions. Declaring `role="group"` helps define the boundaries of the grouped content, making it easier to skip or focus on specific areas of the page.

### `aria-label` in `<figure>`

Adding an `aria-label` to a `<figure>` element, even when the contained `<img>` already has an `aria-label` or `alt` attribute, can provide distinct benefits for web accessibility:

**1. Clarifying the Purpose of the Entire `<figure>`**

The `<figure>` element often groups related content (e.g., an image and a caption) that conveys a more comprehensive meaning than the image alone.

While the `aria-label` or alt on the `<img>` describes the image, an` aria-label` on the `<figure>` can summarize the entire group’s purpose, providing a broader context to assistive technology users.

**2. Supporting Non-Visual Content**

The `<figure>` element might include additional information, such as a `<figcaption>` or supplementary text, that expands on the meaning of the image.

Adding an `aria-label` to the `<figure>` ensures that screen reader users understand the combined meaning of all the content inside the `<figure>`.

**3. Navigational Context**

Screen readers allow users to navigate by regions or landmarks. By labeling the `<figure>` explicitly, users can quickly understand its purpose without needing to explore its contents.

For instance, a figure might represent a "Sales Chart," and its contained image and caption provide detailed information. An aria-label on the `<figure>` gives users an overview.

### `aria-modal="true"` with `role="dialog"`

Adding `aria-modal="true"` to a `<div>` that already has `role="dialog"` provides additional semantic information to assistive technologies, ensuring better accessibility and clarity for screen reader users. Here’s why it's necessary:

**1. Explicitly Indicates Modal Behavior**

The `role="dialog"` alone defines a generic dialog box, which could be modal (requires user interaction before proceeding) or non-modal (can be dismissed or ignored without affecting the main content).

`aria-modal="true"` explicitly specifies that the dialog is modal, meaning interaction with content outside the dialog is not allowed until the dialog is dismissed.

**2. Improves Assistive Technology Behavior**

Screen readers and other assistive technologies can use `aria-modal="true"` to:

- Confine focus to the modal dialog and prevent users from navigating to background content.
- Announce to users that the dialog is modal, reinforcing its significance and required interaction.

Without `aria-modal="true"`, some assistive technologies might allow users to access content outside the modal, leading to confusion or breaking the user flow.

**3. Accessibility Consistency**

While some browsers and assistive technologies infer modal behavior from other implementation details (e.g., focus trapping, backdrop overlay), not all do so reliably.

Adding `aria-modal="true"` ensures a consistent and predictable experience across a wide range of devices and assistive technologies.

**4. Complements `role="dialog"`**

`role="dialog"` and `aria-modal="true"` work together to provide comprehensive semantics:

- `role="dialog"`: Indicates the content is a dialog box.
- `aria-modal="true"`: Indicates the dialog is modal and interaction outside it is restricted.


### When to Add an `aria-label` to a dialog

**If the Dialog Lacks a Visible Label:**

If the dialog does not have a visible heading (`<h1>`, `<h2>`, etc.) or text that can serve as its label, an `aria-label` or `aria-labelledby` is required to provide an accessible name.

**To Provide a Concise and Descriptive Name:**

If the visible heading is too verbose or does not fully describe the purpose of the dialog, an `aria-label` can clarify its intent.