### PR TITLE
Responsive image handling improvements

### DIFF
--- a/src/js/types/image.js
+++ b/src/js/types/image.js
@@ -27,6 +27,10 @@ class ImageType {
       IMAGE.setAttribute('data-srcset', el.getAttribute('data-srcset'))
     }
 
+    if (el.hasAttribute('data-sizes')) {
+      IMAGE.setAttribute('data-sizes', el.getAttribute('data-sizes'))
+    }
+
     // Add image to figure
     FIGURE.appendChild(IMAGE)
 
@@ -100,12 +104,18 @@ class ImageType {
       FIGURE.style.opacity = '1'
     })
 
-    IMAGE.setAttribute('src', IMAGE.getAttribute('data-src'))
-    IMAGE.removeAttribute('data-src')
-
     if (IMAGE.hasAttribute('data-srcset')) {
       IMAGE.setAttribute('srcset', IMAGE.getAttribute('data-srcset'))
+      IMAGE.removeAttribute('data-srcset')
     }
+
+    if (IMAGE.hasAttribute('data-sizes')) {
+      IMAGE.setAttribute('sizes', IMAGE.getAttribute('data-sizes'))
+      IMAGE.removeAttribute('data-sizes')
+    }
+
+    IMAGE.setAttribute('src', IMAGE.getAttribute('data-src'))
+    IMAGE.removeAttribute('data-src')
   }
 
   onLeave (container) {


### PR DESCRIPTION
We needed to be able to use the `sizes`  attribute to properly handle our responsive images.

We also had to handle `srcset` before `src` to avoid loading images twice (`src` and then `srcset`).