### PR TITLE
Fixes the scroll to top when opening lightbox

### DIFF
--- a/src/scss/tobii.scss
+++ b/src/scss/tobii.scss
@@ -46,7 +46,7 @@
 
 // Hide scrollbar if lightbox is displayed
 
-.tobii-is-open {
+body.tobii-is-open {
   overflow-y: hidden;
 }
 


### PR DESCRIPTION
We noticed a strange bug on our side when opening Tobii lightbox.

We could see the page being scrolled to the top behind the dialog overlay.

And we could see the page scroll back down to its original position on dialog close.

This small CSS change fixed the problem on our side.

Don't know if it can be generalized though.